### PR TITLE
add -V to sort for proper order of devices

### DIFF
--- a/lsblk
+++ b/lsblk
@@ -339,7 +339,7 @@ __list_block_devices() {
   ) \
       | sed 's|/dev/||g' \
       | sed -r "s/[[:cntrl:]]\[[0-9]{1,3}m//g" \
-      | sort -u \
+      | sort -uV \
       | sed '/^s*$/d'
 }
 # __list_block_devices() ENDED


### PR DESCRIPTION
before the patch `lsblk -d` printed devices in lexicographical order (da0, da1, da10, da11, da2...)